### PR TITLE
Allow for alternative compiler

### DIFF
--- a/src/socketify/native/Makefile
+++ b/src/socketify/native/Makefile
@@ -1,7 +1,7 @@
 LIBRARY_NAME := libsocketify
 UWS_LIBRARY_NAME := libuwebsockets
-CC := clang
-CXX := clang++
+CC ?= clang
+CXX ?= clang++
 
 ARCH := amd64
 ifeq ($(PLATFORM), arm64)


### PR DESCRIPTION
Ran into this having `clang-11` rather than `clang`

**Description**

This PR fixes compiling on certain linux distributions/configurations

<!--
Thank you for contributing to Socketify.py! 

Contributing Conventions:

1. Include descriptive PR titles.
2. Build and test your changes before submitting a PR. 
-->
