### PR TITLE
Fix Response.send_chunk() and helpers.sendfile()

### DIFF
--- a/src/socketify/socketify.py
+++ b/src/socketify/socketify.py
@@ -1623,13 +1623,14 @@ class AppResponse:
             )  # if aborted set to done True and ok False
             return self._chunkFuture
 
+        self._lastChunkOffset = self.get_write_offset()
+
         (ok, done) = self.try_end(buffer, total_size)
         if ok:
             self._chunkFuture.set_result((ok, done))
             return self._chunkFuture
-        # failed to send chunk
-        self._lastChunkOffset = self.get_write_offset()
 
+        # failed to send chunk
         return self._chunkFuture
 
     def get_data(self):


### PR DESCRIPTION
**Description**

When using Response.send_chunk() or helpers.sendfile() which relies on it, the payload can get corrupted if there is back-pressure from the client. The beginning of the chunk gets sent again when on_writeble() is called.

This PR fixes https://github.com/cirospaciari/socketify.py/issues/149 

Detailed description in issue above.  I have tested this many times using both `curl` and Chrome and serving from both `sendfile()` and also large (1MB) `send_chunk()` chunks.  All on my MacOS M1 localhost.

<!--
Thank you for contributing to Socketify.py! 

Contributing Conventions:

1. Include descriptive PR titles.
2. Build and test your changes before submitting a PR. 
-->
