### PR TITLE
Fix variable naming issue inside listen method

### DIFF
--- a/src/socketify/socketify.py
+++ b/src/socketify/socketify.py
@@ -3315,10 +3315,10 @@ class App:
             native_options = ffi.new("uws_app_listen_config_t *")
             options = native_options[0]
             port = port_or_options.get("port", 0)
-            options = port_or_options.get("options", 0)
+            options_ = port_or_options.get("options", 0)
             host = port_or_options.get("host", "0.0.0.0")
             options.port = (
-                ffi.cast("int", port, 0)
+                ffi.cast("int", port)
                 if isinstance(port, int)
                 else ffi.cast("int", 0)
             )
@@ -3328,8 +3328,8 @@ class App:
                 else ffi.NULL
             )
             options.options = (
-                ffi.cast("int", port)
-                if isinstance(options, int)
+                ffi.cast("int", options_)
+                if isinstance(options_, int)
                 else ffi.cast("int", 0)
             )
             self.native_options_listen = native_options  # Keep alive native_options


### PR DESCRIPTION
**Description**

I couldn't find any existing issues about it, but this is very simple patch regardless.  
This PR fixes the `listen()` function using the same local `options` variable twice despite them being two seperate objects (see the diff for an example).

Additionally, `FFI.cast` only takes 2 arguments, however socketify was giving it 3. That has also been fixed.  
From my testing, this PR works perfectly, otherwise socketify hard crashes with FFI throwing an error for the additional argument.

The code I used to produce these issues in the first place:
```py
app.listen({
    "port": 8080,
    "host": "0.0.0.0"
}, lambda config: print("Running.")) 
```

Sorry if this goes against contribution guidelines, it's just way too simple of a fix to create an issue for in my opinion. It's also a very reproducible problem, I'm surprised I can't find anything about it in Github Issues.