### PR TITLE
Reload functionality

### DIFF
--- a/src/socketify/cli.py
+++ b/src/socketify/cli.py
@@ -134,7 +134,7 @@ def execute(args):
             logging.info('RELOADING...')
             reload_state.reload_pending = False
 
-            # The app.run has already caught SIGTERM which closes the loop then raises SystemExit.
+            # The app.run has already caught SIGTERM which closes the uv/uw loop then raises SystemExit.
             # SIGTERM works across both Windows and Linux
             # Now we respawn the process with the original arguments 
             # Windows
@@ -331,7 +331,7 @@ def _execute(args):
             )
 
         # file watcher
-        def launch_with_file_probe(run_method, user_module_function, loop, poll_frequency=4):
+        def launch_with_file_probe(run_method, user_module_function, poll_frequency=4):
             import importlib.util
             directory = os.path.dirname(importlib.util.find_spec(user_module_function.__module__).origin)
             directory_glob = os.path.join(directory, '**')
@@ -343,7 +343,6 @@ def _execute(args):
             # scandir utility functions
             def _ignore(f):
                 for ignore_pattern in ignore_patterns:
-                    #if '__pycache__' in f or 'node_modules' in f:
                     if ignore_pattern in f:
                         return True
 
@@ -369,7 +368,6 @@ def _execute(args):
                 to emulate glob (which doesnt)
                 """
                 new_files = {} # store path, mtime
-                # [f.stat().st_mtime for f in list(os.scandir('.'))]
                 new_files = _get_dir(directory, new_files)
                 return new_files
 
@@ -387,7 +385,6 @@ def _execute(args):
                     """
                     print('Reloading...')
                     reload_state.reload_pending = True  #signal for Exeute to know whether it is a real external SIGTERM or our own
-                    import signal, sys
                     signal.raise_signal(signal.SIGTERM)  # sigterm works on windows and posix
 
                 return new_files
@@ -430,7 +427,7 @@ def _execute(args):
                 # there's watchfiles module but socketify currently has no external dependencies so
                 # we'll roll our own for now...
                 print(' LAUNCHING WITH RELOAD ', flush=True)
-                launch_with_file_probe(fork_app.run, module, fork_app.loop)
+                launch_with_file_probe(fork_app.run, module)
             else: # run normally
                 fork_app.run()
 

--- a/src/socketify/cli.py
+++ b/src/socketify/cli.py
@@ -236,7 +236,7 @@ def _execute(args):
     elif interface != "socketify":
         return print(f"{interface} interface is not supported yet")
 
-    auto_reload = options.get("--reload", False) or '--reload' in options_list or args.reload
+    auto_reload = options.get("--reload", False) or '--reload' in options_list
     workers = int(
         options.get(
             "--workers", options.get("-w", os.environ.get("WEB_CONCURRENCY", 1))

--- a/src/socketify/loop.py
+++ b/src/socketify/loop.py
@@ -1,7 +1,5 @@
 import asyncio
 import logging
-from time import sleep
-import threading
 from .tasks import create_task, TaskFactory
 from .uv import UVLoop
 
@@ -78,45 +76,8 @@ class Loop:
     def create_future(self):
         return self.loop.create_future()
 
-    def run_uv(self, uv_loop):
-        print('run uv', flush=True)
-        uv_loop.run()
-        #import time
-        #while True:
-        #    time.sleep(1)
-        #    uv_loop.run_nowait()
-
-    def start_uvloop(self):
-        '''
-        import time
-        if not self.started:
-            time.sleep(1)
-            self._keep_alive()
-        '''
-
-        if not hasattr(self, 'thread_started'):
-            logging.info('starting _keep_alive thread')
-            t1 = threading.Thread(target=self.run_uv, daemon=True, args=[self.uv_loop])
-            t1.start()
-        self.thread_started = True
-
     def _keep_alive(self):
-        '''if not self.started:
-            time.sleep(1)
-            self._keep_alive()
-        '''
-        '''
-        if not hasattr(self, 'thread_started'):
-            logging.info('starting _keep_alive thread')
-            t1 = threading.Thread(target=self.run_uv, daemon=True, args=[self.uv_loop])
-            t1.start()
-        '''
-        self.thread_started = True
         if self.started:
-            #sleep(5)  # TODO does this still run?
-            #asyncio.sleep(5)
-            logging.info('Commencing self.started loop checking ')
-            print('in _k_a')
             relax = False
             if not self.is_idle:
                 self._idle_count = 0
@@ -124,20 +85,17 @@ class Loop:
                 self._idle_count += 1
             else:
                 relax = True
-            #print(self._idle_count, relax)
-
+            
             self.is_idle = True
-
+                
             if relax:
-                #self.uv_loop.run()
-                #self.uv_loop.run_nowait()
-                #self.loop.call_later(10, self._keep_alive)
+                self.uv_loop.run_nowait()
                 self.loop.call_later(0.001, self._keep_alive)
             else:
-                #self.uv_loop.run_nowait()
+                self.uv_loop.run_nowait()
                 # be more agressive when needed
                 self.loop.call_soon(self._keep_alive)
-
+                
     def create_task(self, *args, **kwargs):
         # this is not using optimized create_task yet
         return self.loop.create_task(*args, **kwargs)
@@ -151,10 +109,6 @@ class Loop:
             future = self.ensure_future(task)
         else:
             future = None
-        print('RUC', flush=True)
-        # not sure if this method is used. if so,
-        # might want to use self.start_uvloop() here
-        # as well?
         self.loop.call_soon(self._keep_alive)
         self.loop.run_until_complete(future)
         # clean up uvloop
@@ -167,9 +121,7 @@ class Loop:
             future = self.ensure_future(task)
         else:
             future = None
-        print('RUN', flush=True)
-        self.start_uvloop()
-        #self.loop.call_soon(self._keep_alive)
+        self.loop.call_soon(self._keep_alive)
         self.loop.run_forever()
         # clean up uvloop
         self.uv_loop.stop()

--- a/src/socketify/socketify.py
+++ b/src/socketify/socketify.py
@@ -1558,7 +1558,9 @@ class AppResponse:
         return self.app.loop.run_async(task, self)
 
     async def get_form_urlencoded(self, encoding="utf-8"):
+        print('getf u')
         data = await self.get_data()
+        print('got')
         try:
             # decode and unquote all
             result = {}
@@ -3380,10 +3382,15 @@ class App:
         signal.signal(signal.SIGINT, signal_handler)
         
         def reload_signal_handler(sig, frame):
+            print('caught sigterm')
             self.close()
+            print('closed, raising sysexit')
             raise SystemExit('reload')
-
-        signal.signal(signal.SIGUSR1, reload_signal_handler)  # used by --reload in cli.py to reload process
+        
+        #from .cli import RELOAD_SIGNAL # SIGUSR1 SIG_CTRL_BREAK
+        #print(RELOAD_SIGNAL)
+        #print(signal.NSIG)
+        signal.signal(signal.SIGTERM, reload_signal_handler)  # used by --reload in cli.py to reload process
 
         self.loop.run()
         if self.lifespan:

--- a/src/socketify/socketify.py
+++ b/src/socketify/socketify.py
@@ -8,6 +8,7 @@ import signal
 import uuid
 from urllib.parse import parse_qs, quote_plus, unquote_plus
 import logging
+import traceback
 
 from .native import ffi, lib
 from .loop import Loop
@@ -33,7 +34,7 @@ def uws_missing_server_name(hostname, hostname_length, user_data):
                 handler(data)
         except Exception as err:
             logging.error(
-                "Uncaught Exception: %s" % str(err)
+                "Uncaught Exception:\n %s" % traceback.format_exc()
             )  # just log in console the error to call attention
 
 

--- a/src/socketify/socketify.py
+++ b/src/socketify/socketify.py
@@ -68,7 +68,7 @@ def uws_websocket_factory_drain_handler(ws, user_data):
             if dispose:
                 app._ws_factory.dispose(instances)
             logging.error(
-                "Uncaught Exception: %s" % str(err)
+                "Uncaught Exception: %s" % traceback.format_exc()
             )  # just log in console the error to call attention
 
 
@@ -90,7 +90,7 @@ def uws_websocket_drain_handler_with_extension(ws, user_data):
                 handler(ws)
         except Exception as err:
             logging.error(
-                "Uncaught Exception: %s" % str(err)
+                "Uncaught Exception: %s" % traceback.format_exc()
             )  # just log in console the error to call attention
 
 
@@ -108,7 +108,7 @@ def uws_websocket_drain_handler(ws, user_data):
                 handler(ws)
         except Exception as err:
             logging.error(
-                "Uncaught Exception: %s" % str(err)
+                "Uncaught Exception: %s" % traceback.format_exc()
             )  # just log in console the error to call attention
 
 
@@ -190,7 +190,7 @@ def uws_websocket_factory_subscription_handler(
             if dispose:
                 app._ws_factory.dispose(instances)
             logging.error(
-                "Uncaught Exception: %s" % str(err)
+                "Uncaught Exception: %s" % traceback.format_exc()
             )  # just log in console the error to call attention
 
 
@@ -233,7 +233,7 @@ def uws_websocket_subscription_handler(
                 )
         except Exception as err:
             logging.error(
-                "Uncaught Exception: %s" % str(err)
+                "Uncaught Exception: %s" % traceback.format_exc()
             )  # just log in console the error to call attention
 
 
@@ -280,7 +280,7 @@ def uws_websocket_subscription_handler_with_extension(
                 )
         except Exception as err:
             logging.error(
-                "Uncaught Exception: %s" % str(err)
+                "Uncaught Exception: %s" % traceback.format_exc()
             )  # just log in console the error to call attention
 
 
@@ -313,7 +313,7 @@ def uws_websocket_factory_open_handler(ws, user_data):
             if dispose:
                 app._ws_factory.dispose(instances)
             logging.error(
-                "Uncaught Exception: %s" % str(err)
+                "Uncaught Exception: %s" % traceback.format_exc()
             )  # just log in console the error to call attention
 
 
@@ -336,7 +336,7 @@ def uws_websocket_open_handler_with_extension(ws, user_data):
                 handler(ws)
         except Exception as err:
             logging.error(
-                "Uncaught Exception: %s" % str(err)
+                "Uncaught Exception: %s" % traceback.format_exc()
             )  # just log in console the error to call attention
 
 
@@ -355,7 +355,7 @@ def uws_websocket_open_handler(ws, user_data):
                 handler(ws)
         except Exception as err:
             logging.error(
-                "Uncaught Exception: %s" % str(err)
+                "Uncaught Exception: %s" % traceback.format_exc()
             )  # just log in console the error to call attention
 
 
@@ -397,7 +397,7 @@ def uws_websocket_factory_message_handler(ws, message, length, opcode, user_data
             if dispose:
                 app._ws_factory.dispose(instances)
             logging.error(
-                "Uncaught Exception: %s" % str(err)
+                "Uncaught Exception: %s" % traceback.format_exc()
             )  # just log in console the error to call attention
 
 
@@ -431,7 +431,7 @@ def uws_websocket_message_handler_with_extension(
 
         except Exception as err:
             logging.error(
-                "Uncaught Exception: %s" % str(err)
+                "Uncaught Exception: %s" % traceback.format_exc()
             )  # just log in console the error to call attention
 
 
@@ -459,7 +459,7 @@ def uws_websocket_message_handler(ws, message, length, opcode, user_data):
 
         except Exception as err:
             logging.error(
-                "Uncaught Exception: %s" % str(err)
+                "Uncaught Exception: %s" % traceback.format_exc()
             )  # just log in console the error to call attention
 
 
@@ -498,7 +498,7 @@ def uws_websocket_factory_pong_handler(ws, message, length, user_data):
             if dispose:
                 app._ws_factory.dispose(instances)
             logging.error(
-                "Uncaught Exception: %s" % str(err)
+                "Uncaught Exception: %s" % traceback.format_exc()
             )  # just log in console the error to call attention
 
 
@@ -525,7 +525,7 @@ def uws_websocket_pong_handler_with_extension(ws, message, length, user_data):
                 handler(ws, data)
         except Exception as err:
             logging.error(
-                "Uncaught Exception: %s" % str(err)
+                "Uncaught Exception: %s" % traceback.format_exc()
             )  # just log in console the error to call attention
 
 
@@ -548,7 +548,7 @@ def uws_websocket_pong_handler(ws, message, length, user_data):
                 handler(ws, data)
         except Exception as err:
             logging.error(
-                "Uncaught Exception: %s" % str(err)
+                "Uncaught Exception: %s" % traceback.format_exc()
             )  # just log in console the error to call attention
 
 
@@ -588,7 +588,7 @@ def uws_websocket_factory_ping_handler(ws, message, length, user_data):
             if dispose:
                 app._ws_factory.dispose(instances)
             logging.error(
-                "Uncaught Exception: %s" % str(err)
+                "Uncaught Exception: %s" % traceback.format_exc()
             )  # just log in console the error to call attention
 
 
@@ -617,7 +617,7 @@ def uws_websocket_ping_handler_with_extension(ws, message, length, user_data):
 
         except Exception as err:
             logging.error(
-                "Uncaught Exception: %s" % str(err)
+                "Uncaught Exception: %s" % traceback.format_exc()
             )  # just log in console the error to call attention
 
 
@@ -642,7 +642,7 @@ def uws_websocket_ping_handler(ws, message, length, user_data):
 
         except Exception as err:
             logging.error(
-                "Uncaught Exception: %s" % str(err)
+                "Uncaught Exception: %s" % traceback.format_exc()
             )  # just log in console the error to call attention
 
 
@@ -692,7 +692,7 @@ def uws_websocket_factory_close_handler(ws, code, message, length, user_data):
 
         except Exception as err:
             logging.error(
-                "Uncaught Exception: %s" % str(err)
+                "Uncaught Exception: %s" % traceback.format_exc()
             )  # just log in console the error to call attention
 
 
@@ -738,7 +738,7 @@ def uws_websocket_close_handler_with_extension(ws, code, message, length, user_d
 
         except Exception as err:
             logging.error(
-                "Uncaught Exception: %s" % str(err)
+                "Uncaught Exception: %s" % traceback.format_exc()
             )  # just log in console the error to call attention
 
 
@@ -780,7 +780,7 @@ def uws_websocket_close_handler(ws, code, message, length, user_data):
 
         except Exception as err:
             logging.error(
-                "Uncaught Exception: %s" % str(err)
+                "Uncaught Exception: %s" % traceback.format_exc()
             )  # just log in console the error to call attention
 
 
@@ -3421,7 +3421,7 @@ class App:
         if self.error_handler is None:
             try:
                 logging.error(
-                    "Uncaught Exception: %s" % str(error)
+                    "Uncaught Exception: %s" % traceback.format_exc()
                 )  # just log in console the error to call attention
                 response.write_status(500).end("Internal Error")
             finally:
@@ -3438,7 +3438,7 @@ class App:
                 try:
                     # Error handler got an error :D
                     logging.error(
-                        "Uncaught Exception: %s" % str(error)
+                        "Uncaught Exception: %s" % traceback.format_exc()
                     )  # just log in console the error to call attention
                     response.write_status(500).end("Internal Error")
                 finally:

--- a/src/socketify/socketify.py
+++ b/src/socketify/socketify.py
@@ -3378,6 +3378,13 @@ class App:
             exit(0)
 
         signal.signal(signal.SIGINT, signal_handler)
+        
+        def reload_signal_handler(sig, frame):
+            self.close()
+            raise SystemExit('reload')
+
+        signal.signal(signal.SIGUSR1, reload_signal_handler)  # used by --reload in cli.py to reload process
+
         self.loop.run()
         if self.lifespan:
 

--- a/src/socketify/socketify.py
+++ b/src/socketify/socketify.py
@@ -1558,9 +1558,7 @@ class AppResponse:
         return self.app.loop.run_async(task, self)
 
     async def get_form_urlencoded(self, encoding="utf-8"):
-        print('getf u')
         data = await self.get_data()
-        print('got')
         try:
             # decode and unquote all
             result = {}
@@ -3382,14 +3380,11 @@ class App:
         signal.signal(signal.SIGINT, signal_handler)
         
         def reload_signal_handler(sig, frame):
-            print('caught sigterm')
+            """ This signal handler captures a sigterm from cli.py which is a 
+            request to reload the process """
             self.close()
-            print('closed, raising sysexit')
             raise SystemExit('reload')
         
-        #from .cli import RELOAD_SIGNAL # SIGUSR1 SIG_CTRL_BREAK
-        #print(RELOAD_SIGNAL)
-        #print(signal.NSIG)
         signal.signal(signal.SIGTERM, reload_signal_handler)  # used by --reload in cli.py to reload process
 
         self.loop.run()


### PR DESCRIPTION
**Description**

This PR fixes #174

<!--
Thank you for contributing to Socketify.py! 

Contributing Conventions:

1. Include descriptive PR titles.
2. Build and test your changes before submitting a PR. 
-->

Hi, here are some changes for reloading functionality. If --reload is specified the cli.py execute method will poll the files in the run module's directory, excluding some common patterns by default (\_\_pycache\_\_, node_modules). (os.scandir is used recursively as it caches the modified time information on the files it reads)

If the files have been changed, then
- a reload_state flag is set
- the process will be sent a SIGTERM (for posix and windows compatibility).
- the sigterm is handled in run() to close the loop similar to the SIGINT handler and then a sysexit is raised
- then the sysexit is caught back in cli.py execute
    - In execute(). If a flag has been set (reload_state) then the process will restart, if not, the SIGTERM came from another source and the process will simply stop. 

Tested linux, windows.
