### PR TITLE
Reload socketify

### DIFF
--- a/src/socketify/cli.py
+++ b/src/socketify/cli.py
@@ -134,7 +134,7 @@ def execute(args):
             logging.info('RELOADING...')
             reload_state.reload_pending = False
 
-            # The app.run has already caught SIGTERM which closes the loop then raises SystemExit.
+            # The app.run has already caught SIGTERM which closes the uv/uw loop then raises SystemExit.
             # SIGTERM works across both Windows and Linux
             # Now we respawn the process with the original arguments 
             # Windows
@@ -331,7 +331,7 @@ def _execute(args):
             )
 
         # file watcher
-        def launch_with_file_probe(run_method, user_module_function, loop, poll_frequency=4):
+        def launch_with_file_probe(run_method, user_module_function, poll_frequency=4):
             import importlib.util
             directory = os.path.dirname(importlib.util.find_spec(user_module_function.__module__).origin)
             directory_glob = os.path.join(directory, '**')
@@ -343,7 +343,6 @@ def _execute(args):
             # scandir utility functions
             def _ignore(f):
                 for ignore_pattern in ignore_patterns:
-                    #if '__pycache__' in f or 'node_modules' in f:
                     if ignore_pattern in f:
                         return True
 
@@ -369,7 +368,6 @@ def _execute(args):
                 to emulate glob (which doesnt)
                 """
                 new_files = {} # store path, mtime
-                # [f.stat().st_mtime for f in list(os.scandir('.'))]
                 new_files = _get_dir(directory, new_files)
                 return new_files
 
@@ -387,7 +385,6 @@ def _execute(args):
                     """
                     print('Reloading...')
                     reload_state.reload_pending = True  #signal for Exeute to know whether it is a real external SIGTERM or our own
-                    import signal, sys
                     signal.raise_signal(signal.SIGTERM)  # sigterm works on windows and posix
 
                 return new_files
@@ -430,7 +427,7 @@ def _execute(args):
                 # there's watchfiles module but socketify currently has no external dependencies so
                 # we'll roll our own for now...
                 print(' LAUNCHING WITH RELOAD ', flush=True)
-                launch_with_file_probe(fork_app.run, module, fork_app.loop)
+                launch_with_file_probe(fork_app.run, module)
             else: # run normally
                 fork_app.run()
 

--- a/src/socketify/cli.py
+++ b/src/socketify/cli.py
@@ -385,6 +385,7 @@ def _execute(args):
                     """
                     print('Reloading...')
                     reload_state.reload_pending = True  #signal for Exeute to know whether it is a real external SIGTERM or our own
+                    import signal
                     signal.raise_signal(signal.SIGTERM)  # sigterm works on windows and posix
 
                 return new_files

--- a/src/socketify/cli.py
+++ b/src/socketify/cli.py
@@ -385,6 +385,7 @@ def _execute(args):
                     """
                     print('Reloading...')
                     reload_state.reload_pending = True  #signal for Exeute to know whether it is a real external SIGTERM or our own
+                    import signal  # signal is not in scope for some reason 
                     os.kill(os.getpid(), signal.SIGTERM) # sigterm works on windows and posix. raise_signal doesnt seem to send to right proces
 
                 return new_files

--- a/src/socketify/cli.py
+++ b/src/socketify/cli.py
@@ -375,7 +375,7 @@ def _execute(args):
                 """ Get files and their modified time and compare with previous times. 
                 Restart the server if it has changed  """
                 new_files = get_files()
-                if len(new_files) > 50:
+                if len(new_files) > 180:
                     print(f"{len(new_files)} files being watched", new_files)
                 
                 if prev_files is not None and new_files != prev_files:

--- a/src/socketify/cli.py
+++ b/src/socketify/cli.py
@@ -331,7 +331,7 @@ def _execute(args):
             )
 
         # file watcher
-        def launch_with_file_probe(run_method, user_module_function, poll_frequency=4):
+        def launch_with_file_probe(run_method, user_module_function, poll_frequency=3):
             import importlib.util
             directory = os.path.dirname(importlib.util.find_spec(user_module_function.__module__).origin)
             directory_glob = os.path.join(directory, '**')
@@ -375,8 +375,8 @@ def _execute(args):
                 """ Get files and their modified time and compare with previous times. 
                 Restart the server if it has changed  """
                 new_files = get_files()
-                if len(new_files) > 180:
-                    print(f"{len(new_files)} files being watched", new_files)
+                if len(new_files) > 200:
+                    print(f"Warning {len(new_files)} files being watched, --reload-ignore-patterns can be used to reduce number")
                 
                 if prev_files is not None and new_files != prev_files:
                     """ 
@@ -385,8 +385,7 @@ def _execute(args):
                     """
                     print('Reloading...')
                     reload_state.reload_pending = True  #signal for Exeute to know whether it is a real external SIGTERM or our own
-                    import signal
-                    signal.raise_signal(signal.SIGTERM)  # sigterm works on windows and posix
+                    os.kill(os.getpid(), signal.SIGTERM) # sigterm works on windows and posix. raise_signal doesnt seem to send to right proces
 
                 return new_files
                     

--- a/src/socketify/cli.py
+++ b/src/socketify/cli.py
@@ -236,7 +236,7 @@ def _execute(args):
     elif interface != "socketify":
         return print(f"{interface} interface is not supported yet")
 
-    auto_reload = options.get("--reload", False) or '--reload' in options_list or args.reload
+    auto_reload = options.get("--reload", False) or '--reload' in options_list
     workers = int(
         options.get(
             "--workers", options.get("-w", os.environ.get("WEB_CONCURRENCY", 1))

--- a/src/socketify/loop.py
+++ b/src/socketify/loop.py
@@ -1,7 +1,5 @@
 import asyncio
 import logging
-from time import sleep
-import threading
 from .tasks import create_task, TaskFactory
 from .uv import UVLoop
 
@@ -78,45 +76,8 @@ class Loop:
     def create_future(self):
         return self.loop.create_future()
 
-    def run_uv(self, uv_loop):
-        print('run uv', flush=True)
-        uv_loop.run()
-        #import time
-        #while True:
-        #    time.sleep(1)
-        #    uv_loop.run_nowait()
-
-    def start_uvloop(self):
-        '''
-        import time
-        if not self.started:
-            time.sleep(1)
-            self._keep_alive()
-        '''
-
-        if not hasattr(self, 'thread_started'):
-            logging.info('starting _keep_alive thread')
-            t1 = threading.Thread(target=self.run_uv, daemon=True, args=[self.uv_loop])
-            t1.start()
-        self.thread_started = True
-
     def _keep_alive(self):
-        '''if not self.started:
-            time.sleep(1)
-            self._keep_alive()
-        '''
-        '''
-        if not hasattr(self, 'thread_started'):
-            logging.info('starting _keep_alive thread')
-            t1 = threading.Thread(target=self.run_uv, daemon=True, args=[self.uv_loop])
-            t1.start()
-        '''
-        self.thread_started = True
         if self.started:
-            #sleep(5)  # TODO does this still run?
-            #asyncio.sleep(5)
-            logging.info('Commencing self.started loop checking ')
-            print('in _k_a')
             relax = False
             if not self.is_idle:
                 self._idle_count = 0
@@ -124,20 +85,17 @@ class Loop:
                 self._idle_count += 1
             else:
                 relax = True
-            #print(self._idle_count, relax)
-
+            
             self.is_idle = True
-
+                
             if relax:
-                #self.uv_loop.run()
-                #self.uv_loop.run_nowait()
-                #self.loop.call_later(10, self._keep_alive)
+                self.uv_loop.run_nowait()
                 self.loop.call_later(0.001, self._keep_alive)
             else:
-                #self.uv_loop.run_nowait()
+                self.uv_loop.run_nowait()
                 # be more agressive when needed
                 self.loop.call_soon(self._keep_alive)
-
+                
     def create_task(self, *args, **kwargs):
         # this is not using optimized create_task yet
         return self.loop.create_task(*args, **kwargs)
@@ -151,10 +109,6 @@ class Loop:
             future = self.ensure_future(task)
         else:
             future = None
-        print('RUC', flush=True)
-        # not sure if this method is used. if so,
-        # might want to use self.start_uvloop() here
-        # as well?
         self.loop.call_soon(self._keep_alive)
         self.loop.run_until_complete(future)
         # clean up uvloop
@@ -167,9 +121,7 @@ class Loop:
             future = self.ensure_future(task)
         else:
             future = None
-        print('RUN', flush=True)
-        self.start_uvloop()
-        #self.loop.call_soon(self._keep_alive)
+        self.loop.call_soon(self._keep_alive)
         self.loop.run_forever()
         # clean up uvloop
         self.uv_loop.stop()

--- a/src/socketify/socketify.py
+++ b/src/socketify/socketify.py
@@ -1558,7 +1558,9 @@ class AppResponse:
         return self.app.loop.run_async(task, self)
 
     async def get_form_urlencoded(self, encoding="utf-8"):
+        print('getf u')
         data = await self.get_data()
+        print('got')
         try:
             # decode and unquote all
             result = {}
@@ -3380,10 +3382,15 @@ class App:
         signal.signal(signal.SIGINT, signal_handler)
         
         def reload_signal_handler(sig, frame):
+            print('caught sigterm')
             self.close()
+            print('closed, raising sysexit')
             raise SystemExit('reload')
-
-        signal.signal(signal.SIGUSR1, reload_signal_handler)  # used by --reload in cli.py to reload process
+        
+        #from .cli import RELOAD_SIGNAL # SIGUSR1 SIG_CTRL_BREAK
+        #print(RELOAD_SIGNAL)
+        #print(signal.NSIG)
+        signal.signal(signal.SIGTERM, reload_signal_handler)  # used by --reload in cli.py to reload process
 
         self.loop.run()
         if self.lifespan:

--- a/src/socketify/socketify.py
+++ b/src/socketify/socketify.py
@@ -3384,7 +3384,7 @@ class App:
             request to reload the process """
             self.close()
             raise SystemExit('reload')
-        
+
         signal.signal(signal.SIGTERM, reload_signal_handler)  # used by --reload in cli.py to reload process
 
         self.loop.run()

--- a/src/socketify/socketify.py
+++ b/src/socketify/socketify.py
@@ -3378,6 +3378,13 @@ class App:
             exit(0)
 
         signal.signal(signal.SIGINT, signal_handler)
+        
+        def reload_signal_handler(sig, frame):
+            self.close()
+            raise SystemExit('reload')
+
+        signal.signal(signal.SIGUSR1, reload_signal_handler)  # used by --reload in cli.py to reload process
+
         self.loop.run()
         if self.lifespan:
 

--- a/src/socketify/socketify.py
+++ b/src/socketify/socketify.py
@@ -1558,9 +1558,7 @@ class AppResponse:
         return self.app.loop.run_async(task, self)
 
     async def get_form_urlencoded(self, encoding="utf-8"):
-        print('getf u')
         data = await self.get_data()
-        print('got')
         try:
             # decode and unquote all
             result = {}
@@ -3382,14 +3380,11 @@ class App:
         signal.signal(signal.SIGINT, signal_handler)
         
         def reload_signal_handler(sig, frame):
-            print('caught sigterm')
+            """ This signal handler captures a sigterm from cli.py which is a 
+            request to reload the process """
             self.close()
-            print('closed, raising sysexit')
             raise SystemExit('reload')
         
-        #from .cli import RELOAD_SIGNAL # SIGUSR1 SIG_CTRL_BREAK
-        #print(RELOAD_SIGNAL)
-        #print(signal.NSIG)
         signal.signal(signal.SIGTERM, reload_signal_handler)  # used by --reload in cli.py to reload process
 
         self.loop.run()


### PR DESCRIPTION
Description

This PR fixes https://github.com/cirospaciari/socketify.py/issues/174

Hi, here are some changes for reloading functionality. If --reload is specified the cli.py execute method will poll the files in the run module's directory, excluding some common patterns by default (__pycache__, node_modules). (os.scandir is used recursively as it caches the modified time information on the files it reads)

If the files have been changed, then

a reload_state flag is set
the process will be sent a SIGTERM (for posix and windows compatibility).
the sigterm is handled in App.run() to close the loop similar to the SIGINT handler and then a sysexit is raised
this sysexit is caught back in cli.py execute
In execute(). If the flag has been set (reload_state) then the process will restart, if not, the SIGTERM came from another source and the process will simply stop.

Tested linux, windows.











