### PR TITLE
low energy usage loop

### DIFF
--- a/src/socketify/loop.py
+++ b/src/socketify/loop.py
@@ -162,7 +162,7 @@ class Loop:
         check for and process new events """
         # These two lines will both call self._write_to_self and wake the event loop
         #asyncio.run_coroutine_threadsafe(asyncio.sleep(0), self._dataFuture.get_loop())
-        self.loop.call_soon_threadsafe(lambda: 2)  
+        self.loop.call_soon_threadsafe(lambda: 3)  
 
     def run_once(self):
         # run one step of asyncio

--- a/src/socketify/socketify.py
+++ b/src/socketify/socketify.py
@@ -1605,6 +1605,7 @@ class AppResponse:
                     )  # if aborted set to done True and ok False
             except:
                 pass
+            self.app.loop.wake_asyncio_loop()  # wake up async loop after set_result
 
         def on_writeble(self, offset):
             # Here the timeout is off, we can spend as much time before calling try_end we want to
@@ -1613,6 +1614,7 @@ class AppResponse:
             )
             if ok:
                 self._chunkFuture.set_result((ok, done))
+                self.app.loop.wake_asyncio_loop()  # wake up async loop after set_result
             return ok
 
         self.on_writable(on_writeble)
@@ -1622,6 +1624,7 @@ class AppResponse:
             self._chunkFuture.set_result(
                 (False, True)
             )  # if aborted set to done True and ok False
+            self.app.loop.wake_asyncio_loop()  # wake up async loop after set_result
             return self._chunkFuture
 
         self._lastChunkOffset = self.get_write_offset()
@@ -1629,12 +1632,13 @@ class AppResponse:
         (ok, done) = self.try_end(buffer, total_size)
         if ok:
             self._chunkFuture.set_result((ok, done))
+            self.app.loop.wake_asyncio_loop()  # wake up async loop after set_result
             return self._chunkFuture
 
         # failed to send chunk
         return self._chunkFuture
 
-    def get_data(self):
+    async def get_data(self):
         self._dataFuture = self.app.loop.create_future()
         self._data = BytesIO()
 
@@ -1645,6 +1649,7 @@ class AppResponse:
                     self._dataFuture.set_result(self._data)
             except:
                 pass
+            self.app.loop.wake_asyncio_loop()  # wake up async loop after set_result
 
         def get_chunks(self, chunk, is_end):
             if chunk is not None:
@@ -1652,10 +1657,15 @@ class AppResponse:
             if is_end:
                 self._dataFuture.set_result(self._data)
                 self._data = None
+                """
+                    This wakes up the asyncio event loop so that get_data can act on the 
+                    completed _dataFuture
+                """
+                self.app.loop.wake_asyncio_loop()  # wake up async loop after set_result
 
         self.on_aborted(is_aborted)
         self.on_data(get_chunks)
-        return self._dataFuture
+        return await self._dataFuture
 
     def grab_aborted_handler(self):
         # only needed if is async
@@ -3464,4 +3474,3 @@ class App:
                 self.loop = None
         except:
             pass
-


### PR DESCRIPTION
Description

This PR fixes https://github.com/cirospaciari/socketify.py/issues/152

Observed constant 0.1 cpu usage. Following tips from @SnoozeFreddo and @goteguru have looked at the _keep_alive function.

Development route:
Ran uvloop with uv_loop.run() from a new thread.
Cpu usage is still running in the _keep_alive method
Try not running the _keep_alive loop, the rest of the app works fine, except for anything using get_data. Find that after get_data calls set_result on the Future nothing happens, the asyncio run_forever loop doesn't know about the new result.
Wake up the asyncio loop with ( https://stackoverflow.com/questions/71831306/how-can-i-wake-up-an-event-loop-to-notify-it-that-a-future-was-completed-from ) after Future set_result calls (in socketify.py)

Forms, static files, websockets working.
Idle cpu usage seems gone.

Reopened pull request to rebase from cirospaciari/socketify.py main


-- Fixed the PR to rebase off of cirospaciari/socketify.py/main