### PR TITLE
redirect hangs for 8-9 seconds if connection is not ended

### DIFF
--- a/src/socketify/socketify.py
+++ b/src/socketify/socketify.py
@@ -1666,11 +1666,11 @@ class AppResponse:
             )
         return self
 
-    def redirect(self, location, status_code=302):
-        self.write_status(status_code)
-        self.write_header("Location", location)
-        self.end_without_body(False)
-        return self
+    def redirect(self, location, status_code=302, end_connection=True):
+         self.write_status(status_code)
+         self.write_header("Location", location)
+         self.end_without_body(end_connection)  # warning changing default to True, otherwise redirect hangs for 8-9 seconds
+         return self
 
     def write_offset(self, offset):
         lib.uws_res_override_write_offset(

--- a/src/socketify/socketify.py
+++ b/src/socketify/socketify.py
@@ -1667,10 +1667,10 @@ class AppResponse:
         return self
 
     def redirect(self, location, status_code=302, end_connection=True):
-         self.write_status(status_code)
-         self.write_header("Location", location)
-         self.end_without_body(end_connection)  # warning changing default to True, otherwise redirect hangs for 8-9 seconds
-         return self
+        self.write_status(status_code)
+        self.write_header("Location", location)
+        self.end_without_body(end_connection)  # warning changing default to True, otherwise redirect hangs for 8-9 seconds
+        return self
 
     def write_offset(self, offset):
         lib.uws_res_override_write_offset(


### PR DESCRIPTION
**Description**
res.redirect() is currently hanging for 8-9 seconds. It doesn't hang if the connection is ended in the Response.redirect call too.


This PR fixes #186


<!--
Thank you for contributing to Socketify.py! 

Contributing Conventions:

1. Include descriptive PR titles.
2. Build and test your changes before submitting a PR. 
-->
