### PR TITLE
run_once seems to use less cpu

### DIFF
--- a/src/socketify/loop.py
+++ b/src/socketify/loop.py
@@ -89,10 +89,10 @@ class Loop:
             self.is_idle = True
                 
             if relax:
-                self.uv_loop.run_nowait()
+                self.uv_loop.run_once()
                 self.loop.call_later(0.001, self._keep_alive)
             else:
-                self.uv_loop.run_nowait()
+                self.uv_loop.run_once()
                 # be more agressive when needed
                 self.loop.call_soon(self._keep_alive)
                 


### PR DESCRIPTION
**Description**
Following review and advice from @goteguru regarding @snoozeFreddo 's issue, seem to have stumbled on a much more concise solution for the cpu usage that preserves the original code which runs uWebsockets operations on a single thread only - so simple that maybe @cirospaciari didnt use it yet for a reason? 

Have load tested this but would appreciate further review and guidance.



This PR fixes #152 

<!--
Thank you for contributing to Socketify.py! 

Contributing Conventions:

1. Include descriptive PR titles.
2. Build and test your changes before submitting a PR. 
-->
