### PR TITLE
fix high cpu consumption in idle mode

### DIFF
--- a/src/socketify/socketify.py
+++ b/src/socketify/socketify.py
@@ -2617,7 +2617,7 @@ class App:
         websocket_factory_max_items=0,
         task_factory_max_items=100_000,
         lifespan=True,
-        idle_relaxation_time=0,
+        idle_relaxation_time=0.01,
     ):
 
         socket_options_ptr = ffi.new("struct us_socket_context_options_t *")


### PR DESCRIPTION
fixes #194

I still don't know the reason, but seems using `idle_relaxation_time` as 0 started causing the issue, so just updated it back to 0.01.

commit that introduced this change: 70199e8d7d3fac827d409601da346f6c47753b03

before:
![Screenshot from 2024-09-27 19-41-46](https://github.com/user-attachments/assets/547d29e9-bbf7-4f80-a8e5-bba199453f64)

after:
![Screenshot from 2024-09-27 19-47-54](https://github.com/user-attachments/assets/3f54507c-8349-4826-bf20-8707721e41d1)